### PR TITLE
Memory manager refactor

### DIFF
--- a/src/dumpulator/details.py
+++ b/src/dumpulator/details.py
@@ -564,194 +564,110 @@ assert len(interrupt_names) == 32
 
 
 
-class MemoryManager():
-        def __init__(self, uc: Uc):
-            self._memory_map = []
-            self._uc = uc
+"""
+ I'm not sure where to store these values, please change!
+"""
+MEM_RESERVE = 0 
+MEM_COMMIT = 1
+NORMAL_PAGE = 0x1000
+LARGE_PAGE = 0x1000*512
 
-        def mem_protect(self, addr, size, perms):
-            for memory_region in self._memory_map: # Query parents
-                if addr in memory_region and addr+size in memory_region: # Verify that the memory you are altering is inside a parent memory chunk
-                    perms = map_unicorn_perms(perms)
-                    memory_region.children.confliction_check(addr,size) # Identify if there are any conflictions
-                    new_addr, new_size = memory_region.children.mem_protect_correct(addr, size, perms) # Using the conflictions, correct the memory layout
-                    memory_region.children.add_child(ChildMemoryRegion(new_addr,new_size,perms, None, memory_region.start))
-                    self._uc.mem_protect(addr, size, perms)
-                else:
-                    print("MEMORY_MANAGER | Attempted to change write permissions to memory that isn't mapped...")
-            return
 
-        def mem_free(self, addr): # MAJOR : NEED TO MANAGE FREE'ING PARENT MEMORY AND SHRINKING EFFECTED CHILD MEMORY OR DELETING CHILDREN ENTIRELY
-            for memory_region in self._memory_map:
-                if memory_region.start == addr:
-                    self._memory_map.remove(memory_region) # NEED TO ADD SELF._UC.MEM_UNMAP(ADDRESS,SIZE) ASSERT SIZE >= 0x1000
-                    return
-            return
+class MemoryManager:
+    def __init__(self, uc: Uc):
+        self._page_table = {}
+        self._ref_table = {}
+        self._uc = uc
 
-        def mem_allocate(self, addr:int, size:int, perms:int=UC_PROT_ALL, comment=None): # WORKS
-            assert size >= 0x1000
-            if self.check_memory_avail(addr, size) == True:
-                self._memory_map.append(ParentMemoryRegion(addr,size,perms,comment))
-                self._uc.mem_map(addr, size, perms)
-                return
-            else:
-                print("MEMORY_MANAGER | There was an attempt to illegally overmap memory from", addr, "to", addr+size)
-                return
-
-        def mem_find(self, addr): # WORKS
-            for memory_region in self._memory_map: 
-                if addr in memory_region:
-                    return memory_region
-            self.mem_error("MEMORY_MANAGER | Unable to find parent memory for given address...")
-            return 0
-
-        def check_memory_avail(self, addr, size):
-            for memory_region in self._memory_map:
-                if memory_region.query_parent(addr, size) == False:
-                    return True
-                else:
-                    return False
-            return True
-
-        def write(self, addr, data):
-            self._uc.mem_write(addr, data)
-
-        def read(self, addr, size):
-            return self._uc.mem_read(addr, size)
-
-        def readable_contents(self):
-            if len(self._memory_map):
-                for mem_region in self._memory_map:
-                    print("MEMORY_MANAGER | There is a parent block which starts at", mem_region.start, "and ends at", mem_region.end)
-            else:
-                print("MEMORY_MANAGER | There is no memory allocated...")
-
-class MemoryRegionChildL:
-    def __init__(self):
-        self._child_mem_list = []
-        self._conflicting_regions = []
-    
-    def sort(self):
-        length = len(self._child_mem_list)
-        for i in range(length-1):
-            for j in range(0, length-i-1):
-                if self._child_mem_list[j] > self._child_mem_list[j+1]:
-                    swapped = True
-                    self._child_mem_list[j], self._child_mem_list[j+1] = self._child_mem_list[j+1], self._child_mem_list[j]
-            if not swapped:
-                return
-
-    def confliction_check(self, addr, size): # Updates the conflicting memory regions list
-        self._conflicting_regions = []
-        assert len(self._conflicting_regions) == 0 # Make sure that confliction regions is cleared
-        for gen_address in range(addr, addr+size, 0x100):
-            for child_mem in self._child_mem_list:
-                if gen_address in child_mem:
-                    self._conflicting_regions.append(child_mem)
+    def alloc(self, addr:int, size:int, perms:int=AllocationProtect.PAGE_EXECUTE_READWRITE, state:int=MEM_COMMIT, page_size:int=NORMAL_PAGE, comment:str=None):
+        addr = self.page_align_down(addr)
+        size = self.page_align_up(size)
+        if size // LARGE_PAGE >= 1:
+            page_size = LARGE_PAGE
+        alloc_base = addr
+        iter = size // page_size
+        uperms = map_unicorn_perms(perms)
+        self._uc.mem_map(addr, size, uperms)
+        for i in range(iter):
+            self._page_table.update( {addr: MemoryPage(addr, size, alloc_base, perms, state, page_size, comment)})
+            addr += page_size
+        self._ref_table.update( {alloc_base: size} )
         return
 
-    def mem_protect_correct(self, addr, size, perms):
-        new_addr = addr
-        new_size = size
-        for mem_region in self._conflicting_regions: #Clear the area for the new write permissions
-            if new_addr not in mem_region and new_addr+new_size not in mem_region: # No need to correct to split this area, it will be overwritten anyway.
-                self.remove_child(mem_region)
-            elif new_addr in mem_region and new_addr+new_size not in mem_region and mem_region.perms != perms: # The start of the region is in the mem_region, but not the end.
-                mod_region = self.find_child(mem_region)
-                mod_region.end = new_addr
-                mod_region.size = mem_region.end - mem_region.start
-            elif new_addr not in mem_region and new_addr+new_size in mem_region and mem_region.perms != perms:
-                mod_region = self.find_child(mem_region)
-                mod_region.start = new_addr+new_size
-                mod_region.size = mem_region.end - mem_region.start
-            elif new_addr in mem_region and new_addr+new_size in mem_region and mem_region.perms != perms:
-                new_region = ChildMemoryRegion(addr+size, mem_region.end-addr+size, mem_region.perms, mem_region.comment, mem_region.start)
-                mod_region = self.find_child(mem_region)
-                mod_region.end = new_addr
-                mod_region.size = mem_region.end - mem_region.start
-                self._child_mem_list.append(new_region)
-            elif new_addr in mem_region and new_addr+new_size in mem_region and mem_region.perms == perms:
-                return False # The attempted write permissions is within a single child memory block, with the same permissions, its safe to fail the change protection.
-            elif new_addr in mem_region and new_addr+new_size not in mem_region and mem_region.perms == perms:
-                new_addr = mem_region.start
-                new_size += addr - mem_region.start
-                self.remove_child(mem_region)
-            elif new_addr not in mem_region and new_addr+new_size in mem_region and mem_region.perms == perms:
-                new_size += mem_region.end - new_addr+new_size
-                self.remove_child(mem_region)
-            else:
-                print("MEMORY_REGION_CHILD | Unhandled logic in mem_protect_correct")
-                return False
-        return new_addr, new_size
+    def protect(self, addr:int, size:int, perms:int=AllocationProtect.PAGE_EXECUTE_READWRITE, page_size:int=NORMAL_PAGE):
+        addr = self.page_align_down(addr)
+        size = self.page_align_up(size)
+        region, key = self.query(addr)
+        page_size = region.Type
+        iter = size // page_size
+        uperms = map_unicorn_perms(perms)
+        self._uc.mem_protect(addr, size, uperms)
+        try:
+            for i in range(iter):
+                if self._page_table[key].RegionState != MEM_RESERVE:
+                    self._page_table[key].set_protection(perms)
+                    key += page_size
+        except:
+            print("Attempted to modify permissions of a block not allocated/committed")
+            pass
+        return True
 
-    def add_child(self, memory_region):
-        self._child_mem_list.append(memory_region)
-        return
-    
-    def find_child(self, mem_region):
-        for i, mem in enumerate(self._child_mem_list):
-            if mem_region.start == mem.start:
-                return self._child_mem_list[i]
-
-    def remove_child(self, mem_region):
-        for i, mem in enumerate(self._child_mem_list):
-            if mem_region.start == mem.start:
-                del self._child_mem_list[i]
-                break
-
-    def print_contents(self):
-        for i in self._child_mem_list:
-            print("A child memory block starts at", i.start, "ends at", i.start+i.size, "with permissions of", i.perms, "and a comment of", i.comment)
-
-class ChildMemoryRegion:
-    def __init__(self, start_addr, size, perms, comment=None, alloc_base=None):
-        self.region = comment
-        self.start = start_addr
-        self.end = self.start+size
-        self.alloc_base = alloc_base
-        self.size = size
-        self.perms = perms
-        self.comment = comment
-
-    def __gt__(self, other):
-        if self.start > other.start:
-            return True
-        return False
-
-    def __contains__(self, addr):
-        if self.start <= addr and addr <= self.end:
-            # print(self.start, "<=",addr, " & ",addr, "<=", self.end)
-            return True
-        else:
-            return False
-
-class ParentMemoryRegion:
-    def __init__(self, start_addr, size, perms, comment=None, alloc_base=None):
-        self.region = comment
-        self.start = start_addr
-        self.end = self.start+size
-        self.alloc_base = alloc_base
-        self.size = size
-        self.perms = perms
-        self.comment = comment
-        self.children = MemoryRegionChildL()
-
-    @property
-    def is_parent(self):
-        return self.alloc_base is None
-
-    def __contains__(self, addr):
-        if self.start <= addr and addr <= self.end:
-            return True
-        else:
-            return False
-
-    def query_parent(self, addr, size):
-        for gen_address in range(addr, addr+size, 0x100): # Could change the range step
-            if gen_address in self:
+    def free(self, addr:int, size:int=None, page_size:int=NORMAL_PAGE):
+        located_region, _ = self.query(self.page_align_down(addr))
+        page_size = located_region.Type
+        if located_region != False:
+            if size == None:
+                for key in list(self._page_table.keys()):
+                    if self._page_table[key].AllocationBase == located_region.AllocationBase:
+                        del self._page_table[key]
                 return True
+            else:
+                query_addr = located_region.BaseAddress
+                for i in range(size//page_size):
+                    for key in list(self._page_table.keys()):
+                        if query_addr == key:
+                            del self._page_table[key]
+                    query_addr += page_size
+                    return True
+        else:
+            raise Exception
+
+    def query(self, addr:int):
+        for i in self._page_table.items():
+            if self.page_align_down(addr) == i[0]:
+                return i[1], i[0] # Returns the page, and the key to the item in dictionary
         return False
 
-    def print_contents(self):
-        print("MEMORY_REGION | This block starts at", self.start, "ends at", self.end, "with permissions of", self.perms,)
-        return
+    def page_align_up(self, num:int, page_size:int=NORMAL_PAGE):
+        return (num) + ((page_size)-1) & ~((page_size) - 1)
+
+    def page_align_down(self, num:int, page_size:int=NORMAL_PAGE):
+        return (num) & ~(page_size-1)
+
+    """
+    This is the problem child of this memory manager. I don't know a good way to efficiently see if something is going to be "in the way".
+    Hopefully, someone can shed some light or think of a way - or just refactor!
+    
+    """
+     # THE GIVEN INPUT NEEDS TO BE ALIGNED BEFORE PASSING
+    def check(self, addr:int, size:int, page_size:int=NORMAL_PAGE):
+        keylist = self._ref_table.keys()
+        for key in keylist:
+            cmp = key+self._ref_table[key]
+            if (key >= addr and addr+size >= cmp) or (addr >= key and addr+size <= cmp): # This is "lazy" way of catching over-writes, it will not catch everything.
+                return False
+        return True
+
+class MemoryPage:
+    def __init__(self, addr:int, size:int, alloc_base:int, perms:int=AllocationProtect.PAGE_EXECUTE_READWRITE, state:int=MEM_COMMIT, page_size:int=NORMAL_PAGE, comment=None):
+        self.BaseAddress = addr
+        self.AllocationBase = alloc_base
+        self.AllocationProtect = perms
+        self.RegionSize = size
+        self.RegionState = state
+        self.Protect = self.AllocationProtect
+        self.Type = page_size
+        self.RegionName = comment
+    
+    def set_protection(self, prot:int):
+        self.Protect = prot

--- a/src/dumpulator/dumpulator.py
+++ b/src/dumpulator/dumpulator.py
@@ -79,7 +79,7 @@ class Dumpulator(Architecture):
         self.last_module: Optional[minidump.MinidumpModule] = None
 
         self._uc = Uc(UC_ARCH_X86, UC_MODE_64)
-        self._mem_manager = MemoryManager()
+        self._mem_manager = MemoryManager(self._uc)
 
         # TODO: multiple cs instances per segment
         mode = CS_MODE_64 if self._x64 else CS_MODE_32


### PR DESCRIPTION
I rewrote the memory manager to use the paging, although an issue that arose was that the checking function is a bit limited at the moment.

I have had my hand at trying to improve it - it will detect if something was allocating in already allocated space, or "enveloping" allocated space, but if it were to have one 'foot' in at any side of the region - it won't catch the allocation error.

This one is way faster ( mainly because the checker function had to be limited ), hopefully you guys can point me in the right direction if there is something glaringly wrong. Thanks.