### PR TITLE
Basic Export Forwaring

### DIFF
--- a/src/dumpulator/dumpulator.py
+++ b/src/dumpulator/dumpulator.py
@@ -434,6 +434,7 @@ class Dumpulator(Architecture):
                 section.PointerToRawData = section.VirtualAddress
                 section.PointerToRawData_adj = section.VirtualAddress
             self.modules.add(pe, path)
+        self.modules.parse_forwards()
 
     def _setup_syscalls(self):
         # Load the ntdll module from memory

--- a/src/dumpulator/dumpulator.py
+++ b/src/dumpulator/dumpulator.py
@@ -434,7 +434,6 @@ class Dumpulator(Architecture):
                 section.PointerToRawData = section.VirtualAddress
                 section.PointerToRawData_adj = section.VirtualAddress
             self.modules.add(pe, path)
-        self.modules.parse_forwards()
 
     def _setup_syscalls(self):
         # Load the ntdll module from memory
@@ -766,7 +765,7 @@ rsp in KiUserExceptionDispatcher:
                     assert hint_rva is not None, "hint_rva is 0"
                     if hint_rva & ordinal_flag:
                         ordinal = f"#{hint_rva & 0xffff}"
-                        export = dll.find_export(ordinal)
+                        export = self.modules.resolve_export(dll.name, ordinal)
                         assert export is not None, f"Ordinal #{ordinal} not in {dll_name}"
                         imp_va = export.address
                         self.info(f"\t#{ordinal} = {hex(imp_va)}")
@@ -774,7 +773,7 @@ rsp in KiUserExceptionDispatcher:
                         hint = pe.get_word_from_data(pe.get_data(hint_rva, 2), 0)
                         func_name = pe.get_string_at_rva(ilt[idx].AddressOfData + 2, MAX_IMPORT_NAME_LENGTH)
                         func_name = func_name.decode("utf-8")
-                        export = dll.find_export(func_name)
+                        export = self.modules.resolve_export(dll.name, func_name)
                         assert export is not None, f"Export {func_name} not in {dll_name}"
                         imp_va = export.address
                         self.info(f"\t{func_name} = {hex(imp_va)}")

--- a/src/dumpulator/modules.py
+++ b/src/dumpulator/modules.py
@@ -110,15 +110,10 @@ class ModuleManager:
         assert module is not None, f"Could not find module: {module_key}"
         export = module.find_export(function_key)
         assert export is not None, f"Could not find function: {module_key}:{function_key}"
-        if export.forward is None:
-            return export
-        else:
-            fwd_module_name, fwd_export_name = export.forward
-            fwd_module = self.find(fwd_module_name)
-            assert fwd_module is not None, f"Could not resolve export forwarder module: {fwd_module_name}"
-            fwd_export = fwd_module.find_export(fwd_export_name)
-            assert fwd_export is not None, f"Could not resolve export forwarder function: {fwd_export_name}"
-            return fwd_export
+        if export.forward is not None:
+            return self.resolve_export(export.forward[0], export.forward[1])
+        return export
+
 
     def __getitem__(self, key: Union[str, int]) -> Module:
         module = self.find(key)


### PR DESCRIPTION
Resolves export forwards.

1. In `Module`'s `_parse_pe`, if export points to `.rdata` store as an export forwarder (only caveat is x64 `ntdll.dll`'s `RtlNtdllName` which is located in `.rdata`)
2. After all modules have been loaded in iterate over modules to then parse the export forwarders, this is done by overwriting the current export address with the resolved forward export's address
3. If we could not resolve the forwarder leave address to zero and assert we could not resolve the function within `find_export`

Currently does not resolve API sets, but we can cross that bridge later.