### PR TITLE
Implement LazyPageManager

### DIFF
--- a/src/dumpulator/details.py
+++ b/src/dumpulator/details.py
@@ -5,7 +5,7 @@ from typing import List
 from unicorn import *
 from unicorn.x86_const import *
 
-from dumpulator.memory import MemoryProtect
+from dumpulator.memory import MemoryProtect, PageManager
 
 def map_unicorn_perms(protect: MemoryProtect):
     if isinstance(protect, int):
@@ -385,8 +385,9 @@ class Registers:
 
 
 class Arguments:
-    def __init__(self, uc: Uc, regs: Registers, x64):
+    def __init__(self, uc: Uc, memory: PageManager, regs: Registers, x64):
         self._uc = uc
+        self._memory = memory
         self._regs = regs
         self._x64 = x64
 
@@ -395,7 +396,7 @@ class Arguments:
 
         if not self._x64:
             arg_addr = regs.esp + (index + 2) * 4
-            data = self._uc.mem_read(arg_addr, 4)
+            data = self._memory.read(arg_addr, 4)
             return struct.unpack("<I", data)[0]
 
         if index == 0:
@@ -408,7 +409,7 @@ class Arguments:
             return regs.r9
         elif index < 20:
             arg_addr = regs.rsp + (index + 1) * 8
-            data = self._uc.mem_read(arg_addr, 8)
+            data = self._memory.read(arg_addr, 8)
             return struct.unpack("<Q", data)[0]
         else:
             raise Exception("not implemented!")

--- a/src/dumpulator/memory.py
+++ b/src/dumpulator/memory.py
@@ -86,8 +86,7 @@ class MemoryRegion:
         return f"MemoryRegion({hex(self.start)}, {hex(self.size)}, {self.protect}, {self.type}, {repr(self.info)})"
 
     def pages(self):
-        for page in range(self.start, self.end, PAGE_SIZE):
-            yield page
+        return range(self.start, self.end, PAGE_SIZE)
 
 class PageManager:
     def commit(self, addr: int, size: int, protect: MemoryProtect) -> None:
@@ -97,6 +96,12 @@ class PageManager:
         raise NotImplementedError()
 
     def protect(self, addr: int, size: int, protect: MemoryProtect) -> None:
+        raise NotImplementedError()
+
+    def read(self, addr: int, size: int) -> bytearray:
+        raise NotImplementedError()
+
+    def write(self, addr: int, data: bytes) -> None:
         raise NotImplementedError()
 
 class MemoryBasicInformation:
@@ -114,7 +119,7 @@ class MemoryBasicInformation:
         return f"MemoryBasicInformation(base: {hex(self.base)}, allocation_base: {hex(self.allocation_base)}, region_size: {hex(self.region_size)}, state: {self.state}, protect: {self.protect}, type: {self.type})"
 
 class MemoryManager:
-    def __init__(self, page_manager: PageManager, minimum = 0x10000, maximum = 0x7fffffff0000, granularity = 0x10000):
+    def __init__(self, page_manager: PageManager, minimum=0x10000, maximum=0x7fffffff0000, granularity=0x10000):
         self._page_manager = page_manager
         self._minimum = minimum
         self._maximum = maximum
@@ -344,3 +349,9 @@ class MemoryManager:
             regions.append(info)
             addr += info.region_size
         return regions
+
+    def read(self, addr: int, size: int) -> bytearray:
+        return self._page_manager.read(addr, size)
+
+    def write(self, addr: int, data: bytes):
+        return self._page_manager.write(addr, data)

--- a/src/minidump/common_structs.py
+++ b/src/minidump/common_structs.py
@@ -123,7 +123,7 @@ class MinidumpMemorySegment:
 		return mms		
 		
 	def inrange(self, virt_addr):
-		if virt_addr >= self.start_virtual_address and virt_addr < self.end_virtual_address:
+		if self.start_virtual_address <= virt_addr < self.end_virtual_address:
 			return True
 		return False
 	


### PR DESCRIPTION
Closes #35

This is a very naïve implementation. It stores a map of `page_address -> LazyPage` in the `PageManager`. Initially none of the pages are `committed`, so once execution starts it raises a memory exception. Once this happens the page is committed and emulation resumed.

There is no optimization done on the data structure yet, so a 10GB RW page would create ~10 million dictionary entries. The speedup is still very significant though.