### PR TITLE
Add support for win32k syscalls

### DIFF
--- a/src/dumpulator/details.py
+++ b/src/dumpulator/details.py
@@ -395,7 +395,7 @@ class Arguments:
         regs = self._regs
 
         if not self._x64:
-            arg_addr = regs.esp + (index + 2) * 4
+            arg_addr = regs.esp + (index + 1) * 4
             data = self._memory.read(arg_addr, 4)
             return struct.unpack("<I", data)[0]
 


### PR DESCRIPTION
This allows you to do this:

```python
from dumpulator import *
from dumpulator.native import *

class HDC(HANDLE):
    pass

class HWND(HANDLE):
    pass

class HFONT(HANDLE):
    pass

@syscall
def NtUserModifyUserStartupInfoFlags(dp: Dumpulator,
                                     Set: ULONG,
                                     Flags: ULONG):
    return 0

@syscall
def NtUserGetDCEx(dp: Dumpulator,
                  hWnd: HWND,
                  hRegion: HANDLE,
                  Flags: ULONG) -> HDC:
    return dp.handles.new("HDC")

@syscall
def NtGdiHfontCreate(dp: Dumpulator,
                     pelfw: PVOID,
                     cjElfw: ULONG,
                     lft: ULONG,
                     fl: ULONG,
                     pvCliData: ULONG) -> HFONT:
    return dp.handles.new("HFONT")
```