### PR TITLE
Module loading improvement

### DIFF
--- a/src/dumpulator/details.py
+++ b/src/dumpulator/details.py
@@ -584,6 +584,9 @@ def format_table(table: List[List[str]]):
         for index, col in enumerate(row):
             if index > 0:
                 line += " "
-            line += f"{col:>{lengths[index]}}"
+            if index + 1 == len(row):
+                line += col
+            else:
+                line += f"{col:>{lengths[index]}}"
         result += line.rstrip()
     return result

--- a/src/dumpulator/dumpulator.py
+++ b/src/dumpulator/dumpulator.py
@@ -820,6 +820,9 @@ class Dumpulator(Architecture):
                 # Potentially interesting members: Misc_PhysicalAddress, Misc_VirtualSize, SizeOfRawData
                 section.PointerToRawData = section.VirtualAddress
                 section.PointerToRawData_adj = section.VirtualAddress
+            # Do not trust these values from memory
+            pe.OPTIONAL_HEADER.ImageBase = base
+            pe.OPTIONAL_HEADER.ImageSize = size
             self.modules.add(pe, path)
 
     def _setup_syscalls(self):

--- a/src/dumpulator/modules.py
+++ b/src/dumpulator/modules.py
@@ -137,3 +137,6 @@ class ModuleManager:
     def __iter__(self):
         for base in self._modules:
             yield self._modules[base]
+
+    def __repr__(self) -> str:
+        return f"ModuleManager(main={hex(self.main)}, modules={len(self._modules)})"


### PR DESCRIPTION
Previously untrusted input (the memory of the minidump) would be used for the module base and size.